### PR TITLE
Fix CORS configuration to handle allowCredentials correctly

### DIFF
--- a/backend/src/main/java/com/example/demo/security/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/security/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOrigin("*");
+        config.addAllowedOriginPattern("*");
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         source.registerCorsConfiguration("/**", config);


### PR DESCRIPTION
Fixes #8

Update `SecurityConfig.java` to handle `Access-Control-Allow-Origin` correctly when `allowCredentials` is true.

* Replace `addAllowedOrigin("*")` with `addAllowedOriginPattern("*")` in the `corsFilter` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/switchover/copilot-ws-user-authentication-system/issues/8?shareId=169cdf7c-3c99-4684-8485-59736ffb3cfd).