### PR TITLE
Fix pathRewrite configuration in vue.config.js

### DIFF
--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -6,8 +6,7 @@ module.exports = {
     proxy: {
       '/api': {
         target: 'http://localhost:8080',
-        changeOrigin: true,
-        pathRewrite: { '^/api': '' }
+        changeOrigin: true
       }
     }
   }


### PR DESCRIPTION
Remove incorrect `pathRewrite` configuration in `frontend/vue.config.js`.

* Remove the `pathRewrite` configuration from the `devServer.proxy` object.
* Ensure the `target` is set to `http://localhost:8080`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/switchover/copilot-ws-user-authentication-system?shareId=2fc8f3fb-cfd7-4cd6-bb2e-1800e77518a8).